### PR TITLE
New rules AliasTraitMethod and AddMethodCall...

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 3 Rules Overview
+# 4 Rules Overview
 
 ## AddInterfaceToClassExtendingTypeRector
 
@@ -65,6 +65,48 @@ use Sylius\Component\Core\Model\Channel as BaseChannel;
 class Channel extends BaseChannel
 {
 +    use \Sylius\MultiStorePlugin\CustomerPools\Domain\Model\CustomerPoolAwareTrait;
+}
+```
+
+## AddMethodCallToConstructorForClassesUsingTraitRector
+
+Adds given method calls to constructor for classes using given trait
+
+:wrench: **configure it!**
+
+- class: [`Sylius\SyliusRector\Rector\Class_\AddMethodCallToConstructorForClassesUsingTraitRector`](../src/Rector/Class_/AddMethodCallToConstructorForClassesUsingTraitRector.php)
+
+```php
+use Rector\Config\RectorConfig;
+use Sylius\SyliusRector\Rector\Class_\AddTraitToClassExtendingTypeRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(AddMethodCallToConstructorForClassesUsingTraitRector::class, [
+        'Sylius\MultiStorePlugin\CustomerPools\Domain\Model\CustomerPoolAwareTrait' => [
+            [
+                'variableName' => 'this',
+                'method' => 'initializeSomething',
+                'arguments' => [],
+            ],
+        ],
+    ]);
+};
+
+
+```
+
+↓
+
+```diff
+use Sylius\Component\Core\Model\Channel as BaseChannel;
+
+class Channel extends BaseChannel
+{
+    use \Sylius\MultiStorePlugin\CustomerPools\Domain\Model\CustomerPoolAwareTrait;
+    public function __construct()
+    {
++        $this->initializeSomething();
+    }
 }
 ```
 

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 2 Rules Overview
+# 3 Rules Overview
 
 ## AddInterfaceToClassExtendingTypeRector
 
@@ -65,5 +65,46 @@ use Sylius\Component\Core\Model\Channel as BaseChannel;
 class Channel extends BaseChannel
 {
 +    use \Sylius\MultiStorePlugin\CustomerPools\Domain\Model\CustomerPoolAwareTrait;
+}
+```
+
+## AliasTraitMethodRector
+
+Aliases the given trait's method to the given name
+
+:wrench: **configure it!**
+
+- class: [`Sylius\SyliusRector\Rector\TraitUse\AliasTraitMethodRector`](../src/Rector/TraitUse/AliasTraitMethodRector.php)
+
+```php
+use Rector\Config\RectorConfig;
+use Sylius\SyliusRector\Rector\Class_\AddTraitToClassExtendingTypeRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(AliasTraitMethodRector::class, [
+        'Sylius\MultiStorePlugin\CustomerPools\Domain\Model\CustomerPoolAwareTrait' => [
+            [
+                'traitMethod' => '__construct',
+                'newMethodName' => 'initializeSomething',
+                'visibility' => Class_::MODIFIER_PRIVATE,
+            ],
+        ],
+    ]);
+};
+
+
+```
+
+↓
+
+```diff
+use Sylius\Component\Core\Model\Channel as BaseChannel;
+
+class Channel extends BaseChannel
+{
+-    use \Sylius\MultiStorePlugin\CustomerPools\Domain\Model\CustomerPoolAwareTrait;
++    use \Sylius\MultiStorePlugin\CustomerPools\Domain\Model\CustomerPoolAwareTrait {
++        __construct as private initializeSomething;
++    }
 }
 ```

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -79,15 +79,12 @@ Adds given method calls to constructor for classes using given trait
 ```php
 use Rector\Config\RectorConfig;
 use Sylius\SyliusRector\Rector\Class_\AddTraitToClassExtendingTypeRector;
+use Sylius\SyliusRector\Rector\Dto\AddMethodCallToConstructorForClassesUsingTrait;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->ruleWithConfiguration(AddMethodCallToConstructorForClassesUsingTraitRector::class, [
         'Sylius\MultiStorePlugin\CustomerPools\Domain\Model\CustomerPoolAwareTrait' => [
-            [
-                'variableName' => 'this',
-                'method' => 'initializeSomething',
-                'arguments' => [],
-            ],
+            new AddMethodCallToConstructorForClassesUsingTrait('this', 'initializeSomething'),
         ],
     ]);
 };

--- a/src/NodeManipulator/TraitManipulator.php
+++ b/src/NodeManipulator/TraitManipulator.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Sylius\SyliusRector\NodeManipulator;

--- a/src/NodeManipulator/TraitManipulator.php
+++ b/src/NodeManipulator/TraitManipulator.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace Sylius\SyliusRector\NodeManipulator;
+
+use PhpParser\Node\Stmt\TraitUse;
+use PhpParser\Node\Stmt\TraitUseAdaptation\Alias;
+
+final class TraitManipulator
+{
+    public function hasAliasForMethod(TraitUse $trait, string $methodName): bool
+    {
+        foreach ($trait->adaptations as $adaptation) {
+            if (!$adaptation instanceof Alias) {
+                continue;
+            }
+
+            if ($adaptation->method->toString() === $methodName) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function removeAliasForMethod(TraitUse $trait, string $methodName): void
+    {
+        foreach ($trait->adaptations as $key => $adaptation) {
+            if (!$adaptation instanceof Alias) {
+                continue;
+            }
+
+            if ($adaptation->method->toString() === $methodName) {
+                unset($trait->adaptations[$key]);
+            }
+        }
+    }
+}

--- a/src/Rector/Class_/AddMethodCallToConstructorForClassesUsingTraitRector.php
+++ b/src/Rector/Class_/AddMethodCallToConstructorForClassesUsingTraitRector.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Sylius\SyliusRector\Rector\Class_;
@@ -16,14 +17,12 @@ use Rector\Core\NodeManipulator\ClassInsertManipulator;
 use Rector\Core\NodeManipulator\ClassManipulator;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\MethodName;
-use Sylius\SyliusRector\NodeManipulator\ClassInterfaceManipulator;
 use Symplify\RuleDocGenerator\Exception\PoorDocumentationException;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
-use function RectorPrefix202208\dump;
 
 /**
- * @see \Sylius\SyliusRector\Tests\Rector\Class_\AddMethodCallToConstructor\AddMethodCallToConstructorTest
+ * @see \Sylius\SyliusRector\Tests\Rector\Class_\AddMethodCallToConstructorForClassesUsingTrait\AddMethodCallToConstructorForClassesUsingTraitTest
  */
 final class AddMethodCallToConstructorForClassesUsingTraitRector extends AbstractRector implements ConfigurableRectorInterface
 {
@@ -46,17 +45,23 @@ final class AddMethodCallToConstructorForClassesUsingTraitRector extends Abstrac
             [
                 new CodeSample(
                     <<<CODE_SAMPLE
-                use Sylius\Component\Channel\Model\Channel as BaseChannel;
-                
+                use Sylius\Component\Core\Model\Channel as BaseChannel;
+
                 class Channel extends BaseChannel
                 {
+                    use \Sylius\MultiStorePlugin\CustomerPools\Domain\Model\CustomerPoolAwareTrait;
                 }
                 CODE_SAMPLE,
                     <<<CODE_SAMPLE
-                use Sylius\Component\Channel\Model\Channel as BaseChannel;
-                
-                class Channel extends BaseChannel implements \Sylius\MultiStorePlugin\BusinessUnits\Domain\Model\ChannelInterface
+                use Sylius\Component\Core\Model\Channel as BaseChannel;
+
+                class Channel extends BaseChannel
                 {
+                    use \Sylius\MultiStorePlugin\CustomerPools\Domain\Model\CustomerPoolAwareTrait;
+                    public function __construct()
+                    {
+                        \$this->initializeSomething();
+                    }
                 }
                 CODE_SAMPLE
                 ),
@@ -83,9 +88,9 @@ final class AddMethodCallToConstructorForClassesUsingTraitRector extends Abstrac
         $newConstructorStmts = [];
 
         foreach ($this->configuration as $structureName => $methodCallConfiguration) {
-
             if (trait_exists($structureName)) {
                 $newConstructorStmts = array_merge($newConstructorStmts, $this->processTrait($node, $structureName, $methodCallConfiguration));
+
                 continue;
             }
 

--- a/src/Rector/Class_/AddMethodCallToConstructorForClassesUsingTraitRector.php
+++ b/src/Rector/Class_/AddMethodCallToConstructorForClassesUsingTraitRector.php
@@ -17,6 +17,7 @@ use Rector\Core\NodeManipulator\ClassInsertManipulator;
 use Rector\Core\NodeManipulator\ClassManipulator;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\MethodName;
+use Sylius\SyliusRector\Rector\Dto\AddMethodCallToConstructorForClassesUsingTrait;
 use Symplify\RuleDocGenerator\Exception\PoorDocumentationException;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -116,7 +117,7 @@ final class AddMethodCallToConstructorForClassesUsingTraitRector extends Abstrac
     }
 
     /**
-     * @param array<array{"variableName": string, "method": string, "arguments": array<string>}> $methodsCallsConfiguration
+     * @param array<AddMethodCallToConstructorForClassesUsingTrait> $methodsCallsConfiguration
      * @return array<Node>
      */
     private function processTrait(Class_ $node, string $traitName, array $methodsCallsConfiguration): array
@@ -129,9 +130,9 @@ final class AddMethodCallToConstructorForClassesUsingTraitRector extends Abstrac
 
         foreach ($methodsCallsConfiguration as $methodCallConfiguration) {
             $methodCall = $this->nodeFactory->createMethodCall(
-                $methodCallConfiguration['variableName'],
-                $methodCallConfiguration['method'],
-                $methodCallConfiguration['arguments']
+                $methodCallConfiguration->getVariable(),
+                $methodCallConfiguration->getMethod(),
+                $methodCallConfiguration->getArguments(),
             );
 
             $nodes[] = new Expression($methodCall);

--- a/src/Rector/Class_/AddMethodCallToConstructorForClassesUsingTraitRector.php
+++ b/src/Rector/Class_/AddMethodCallToConstructorForClassesUsingTraitRector.php
@@ -1,0 +1,182 @@
+<?php
+declare(strict_types=1);
+
+namespace Sylius\SyliusRector\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Expression;
+use Rector\Compatibility\NodeFactory\ConstructorClassMethodFactory;
+use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Core\NodeManipulator\ClassInsertManipulator;
+use Rector\Core\NodeManipulator\ClassManipulator;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\ValueObject\MethodName;
+use Sylius\SyliusRector\NodeManipulator\ClassInterfaceManipulator;
+use Symplify\RuleDocGenerator\Exception\PoorDocumentationException;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use function RectorPrefix202208\dump;
+
+/**
+ * @see \Sylius\SyliusRector\Tests\Rector\Class_\AddMethodCallToConstructor\AddMethodCallToConstructorTest
+ */
+final class AddMethodCallToConstructorForClassesUsingTraitRector extends AbstractRector implements ConfigurableRectorInterface
+{
+    private array $configuration = [];
+
+    public function __construct(
+        private ConstructorClassMethodFactory $constructorClassMethodFactory,
+        private ClassInsertManipulator $classInsertManipulator,
+        private ClassManipulator $classManipulator,
+    ) {
+    }
+
+    /**
+     * @throws PoorDocumentationException
+     */
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Adds given method calls to constructor for classes using given trait',
+            [
+                new CodeSample(
+                    <<<CODE_SAMPLE
+                use Sylius\Component\Channel\Model\Channel as BaseChannel;
+                
+                class Channel extends BaseChannel
+                {
+                }
+                CODE_SAMPLE,
+                    <<<CODE_SAMPLE
+                use Sylius\Component\Channel\Model\Channel as BaseChannel;
+                
+                class Channel extends BaseChannel implements \Sylius\MultiStorePlugin\BusinessUnits\Domain\Model\ChannelInterface
+                {
+                }
+                CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    public function configure(array $configuration): void
+    {
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * @param Class_ $node
+     * @throws \Exception
+     */
+    public function refactor(Node $node): Node|array|null
+    {
+        $newConstructorStmts = [];
+
+        foreach ($this->configuration as $structureName => $methodCallConfiguration) {
+
+            if (trait_exists($structureName)) {
+                $newConstructorStmts = array_merge($newConstructorStmts, $this->processTrait($node, $structureName, $methodCallConfiguration));
+                continue;
+            }
+
+            throw new \Exception();
+        }
+
+
+        $constructor = $this->getOrCreateConstructorMethod($node);
+
+        foreach ($newConstructorStmts as $newConstructorStmt) {
+            if (!$newConstructorStmt instanceof Expression || !$newConstructorStmt->expr instanceof MethodCall) {
+                continue;
+            }
+
+            if ($this->isConstructMethodCallAlreadyExisting($constructor, $newConstructorStmt->expr)) {
+                continue;
+            }
+
+            $constructor->stmts[] = $newConstructorStmt;
+        }
+
+        return $node;
+    }
+
+    /**
+     * @param array<array{"variableName": string, "method": string, "arguments": array<string>}> $methodsCallsConfiguration
+     * @return array<Node>
+     */
+    private function processTrait(Class_ $node, string $traitName, array $methodsCallsConfiguration): array
+    {
+        if (! $this->classManipulator->hasTrait($node, $traitName)) {
+            return [];
+        }
+
+        $nodes = [];
+
+        foreach ($methodsCallsConfiguration as $methodCallConfiguration) {
+            $methodCall = $this->nodeFactory->createMethodCall(
+                $methodCallConfiguration['variableName'],
+                $methodCallConfiguration['method'],
+                $methodCallConfiguration['arguments']
+            );
+
+            $nodes[] = new Expression($methodCall);
+        }
+
+        return $nodes;
+    }
+
+    private function getOrCreateConstructorMethod(Class_ $node): ClassMethod
+    {
+        $constructor = $node->getMethod(MethodName::CONSTRUCT);
+
+        if (null === $constructor) {
+            $constructor = $this->constructorClassMethodFactory->createConstructorClassMethod([], []);
+            $this->classInsertManipulator->addAsFirstMethod($node, $constructor);
+        }
+
+        return $constructor;
+    }
+
+    private function isConstructMethodCallAlreadyExisting(ClassMethod $constructor, MethodCall $newMethodCall): bool
+    {
+        foreach ($constructor->stmts as $stmt) {
+            if (! $stmt instanceof Expression) {
+                continue;
+            }
+
+            if (! $stmt->expr instanceof MethodCall) {
+                continue;
+            }
+
+            if (! $this->areMethodCallsEqual($stmt->expr, $newMethodCall)) {
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private function areMethodCallsEqual(MethodCall $methodCall, MethodCall $anotherMethodCall): bool
+    {
+        return $methodCall->var instanceof Variable
+            && $anotherMethodCall->var instanceof Variable
+            && $methodCall->var->name === $anotherMethodCall->var->name
+            && $methodCall->name instanceof Identifier
+            && $anotherMethodCall->name instanceof Identifier
+            && $methodCall->name->name === $anotherMethodCall->name->name
+            && $methodCall->args === $anotherMethodCall->args
+        ;
+    }
+}

--- a/src/Rector/Dto/AddMethodCallToConstructorForClassesUsingTrait.php
+++ b/src/Rector/Dto/AddMethodCallToConstructorForClassesUsingTrait.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\SyliusRector\Rector\Dto;
+
+final class AddMethodCallToConstructorForClassesUsingTrait
+{
+    /**
+     * @param array<array-key, mixed> $arguments
+     */
+    public function __construct(
+        private string $variable,
+        private string $method,
+        private array $arguments = [],
+    ) {
+    }
+
+    public function getVariable(): string
+    {
+        return $this->variable;
+    }
+
+    public function getMethod(): string
+    {
+        return $this->method;
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    public function getArguments(): array
+    {
+        return $this->arguments;
+    }
+}

--- a/src/Rector/TraitUse/AliasTraitMethodRector.php
+++ b/src/Rector/TraitUse/AliasTraitMethodRector.php
@@ -1,0 +1,113 @@
+<?php
+declare(strict_types=1);
+
+namespace Sylius\SyliusRector\Rector\TraitUse;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\TraitUse;
+use PhpParser\Node\Stmt\TraitUseAdaptation\Alias;
+use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Core\Rector\AbstractRector;
+use Sylius\SyliusRector\NodeManipulator\TraitManipulator;
+use Symplify\RuleDocGenerator\Exception\PoorDocumentationException;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Sylius\SyliusRector\Tests\Rector\TraitUse\AliasTraitMethod\AliasTraitMethodTest
+ */
+final class AliasTraitMethodRector extends AbstractRector implements ConfigurableRectorInterface
+{
+    private array $aliasTraitMethodRectorConfig = [];
+
+    public function __construct(
+        private TraitManipulator $traitManipulator,
+    ) {
+    }
+
+    /**
+     * @throws PoorDocumentationException
+     */
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Aliases the given trait\'s method to the given name',
+            [
+                new CodeSample(
+                    <<<CODE_SAMPLE
+                use Sylius\Component\Channel\Model\Channel as BaseChannel;
+                
+                class Channel extends BaseChannel
+                {
+                    use SomeTrait;
+                }
+                CODE_SAMPLE,
+                    <<<CODE_SAMPLE
+                use Sylius\Component\Channel\Model\Channel as BaseChannel;
+                
+                class Channel extends BaseChannel implements \Sylius\MultiStorePlugin\BusinessUnits\Domain\Model\ChannelInterface
+                {
+                    use SomeTrait {
+                        __construct as private initializeSomething;
+                    }
+                }
+                CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [TraitUse::class];
+    }
+
+    public function configure(array $configuration): void
+    {
+        $this->aliasTraitMethodRectorConfig = $configuration;
+    }
+
+    public function refactor(TraitUse|Node $node): Node
+    {
+        if (!$node instanceof TraitUse) {
+            return $node;
+        }
+
+        foreach ($node->traits as $trait) {
+            if (!$this->isTraitSupported($trait)) {
+                continue;
+            }
+
+            foreach ($this->getConfigurationForTrait($trait) as $configurationEntry) {
+                if ($this->traitManipulator->hasAliasForMethod($node, $configurationEntry['traitMethod'])) {
+                    $this->traitManipulator->removeAliasForMethod($node, $configurationEntry['traitMethod']);
+                }
+
+                $node->adaptations[] = $this->createAlias($configurationEntry);
+            }
+        }
+
+        return $node;
+    }
+
+    private function isTraitSupported(Node\Name $traitName): bool
+    {
+        return in_array($traitName->toString(), array_keys($this->aliasTraitMethodRectorConfig), true);
+    }
+
+    /**
+     * @return array<string, array<string>>
+     */
+    private function getConfigurationForTrait(Node\Name $traitName): array
+    {
+        return $this->aliasTraitMethodRectorConfig[$traitName->toString()];
+    }
+
+    /**
+     * @param array<string, string> $configuration
+     */
+    private function createAlias(array $configuration): Alias
+    {
+        return new Alias(null, $configuration['traitMethod'], (int) $configuration['visibility'], $configuration['newMethodName']);
+    }
+}

--- a/src/Rector/TraitUse/AliasTraitMethodRector.php
+++ b/src/Rector/TraitUse/AliasTraitMethodRector.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Sylius\SyliusRector\Rector\TraitUse;

--- a/stubs/Sylius/MultiStorePlugin/BusinessUnits/Domain/Model/BusinessUnitAwareTrait.php
+++ b/stubs/Sylius/MultiStorePlugin/BusinessUnits/Domain/Model/BusinessUnitAwareTrait.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Sylius\MultiStorePlugin\BusinessUnits\Domain\Model;
+
+if (trait_exists('Sylius\MultiStorePlugin\BusinessUnits\Domain\Model\BusinessUnitAwareTrait')) {
+    return;
+}
+
+trait BusinessUnitAwareTrait
+{
+
+}

--- a/stubs/Sylius/MultiStorePlugin/BusinessUnits/Domain/Model/BusinessUnitAwareTrait.php
+++ b/stubs/Sylius/MultiStorePlugin/BusinessUnits/Domain/Model/BusinessUnitAwareTrait.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Sylius\MultiStorePlugin\BusinessUnits\Domain\Model;
@@ -9,5 +10,4 @@ if (trait_exists('Sylius\MultiStorePlugin\BusinessUnits\Domain\Model\BusinessUni
 
 trait BusinessUnitAwareTrait
 {
-
 }

--- a/stubs/Sylius/MultiStorePlugin/CustomerPools/Domain/Model/CustomerPoolAwareTrait.php
+++ b/stubs/Sylius/MultiStorePlugin/CustomerPools/Domain/Model/CustomerPoolAwareTrait.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Sylius\MultiStorePlugin\CustomerPools\Domain\Model;
+
+if (trait_exists('Sylius\MultiStorePlugin\CustomerPools\Domain\Model\CustomerPoolAwareTrait')) {
+    return;
+}
+
+trait CustomerPoolAwareTrait
+{
+
+}

--- a/stubs/Sylius/MultiStorePlugin/CustomerPools/Domain/Model/CustomerPoolAwareTrait.php
+++ b/stubs/Sylius/MultiStorePlugin/CustomerPools/Domain/Model/CustomerPoolAwareTrait.php
@@ -9,5 +9,4 @@ if (trait_exists('Sylius\MultiStorePlugin\CustomerPools\Domain\Model\CustomerPoo
 
 trait CustomerPoolAwareTrait
 {
-
 }

--- a/tests/Rector/Class_/AddMethodCallToConstructorForClassesUsingTrait/AddMethodCallToConstructorForClassesUsingTraitTest.php
+++ b/tests/Rector/Class_/AddMethodCallToConstructorForClassesUsingTrait/AddMethodCallToConstructorForClassesUsingTraitTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\SyliusRector\Tests\Rector\Class_\AddMethodCallToConstructorForClassesUsingTrait;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class AddMethodCallToConstructorForClassesUsingTraitTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/Class_/AddMethodCallToConstructorForClassesUsingTrait/Fixture/class_with_constructor.php.inc
+++ b/tests/Rector/Class_/AddMethodCallToConstructorForClassesUsingTrait/Fixture/class_with_constructor.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Sylius\SyliusRector\Tests\Rector\Class_\AddMethodCallToConstructorForClassesUsingTrait\Fixture;
+
+use Sylius\Component\Core\Model\Channel as BaseChannel;
+
+class Channel extends BaseChannel
+{
+    use \Sylius\MultiStorePlugin\CustomerPools\Domain\Model\CustomerPoolAwareTrait;
+    public function __construct()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Sylius\SyliusRector\Tests\Rector\Class_\AddMethodCallToConstructorForClassesUsingTrait\Fixture;
+
+use Sylius\Component\Core\Model\Channel as BaseChannel;
+
+class Channel extends BaseChannel
+{
+    use \Sylius\MultiStorePlugin\CustomerPools\Domain\Model\CustomerPoolAwareTrait;
+    public function __construct()
+    {
+        $this->initializeSomething();
+    }
+}
+
+?>

--- a/tests/Rector/Class_/AddMethodCallToConstructorForClassesUsingTrait/Fixture/class_with_constructor_and_the_same_method_call.php.inc
+++ b/tests/Rector/Class_/AddMethodCallToConstructorForClassesUsingTrait/Fixture/class_with_constructor_and_the_same_method_call.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Sylius\SyliusRector\Tests\Rector\Class_\AddMethodCallToConstructorForClassesUsingTrait\Fixture;
+
+use Sylius\Component\Core\Model\Channel as BaseChannel;
+
+class Channel extends BaseChannel
+{
+    use \Sylius\MultiStorePlugin\CustomerPools\Domain\Model\CustomerPoolAwareTrait;
+    public function __construct()
+    {
+        $this->initializeSomething();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Sylius\SyliusRector\Tests\Rector\Class_\AddMethodCallToConstructorForClassesUsingTrait\Fixture;
+
+use Sylius\Component\Core\Model\Channel as BaseChannel;
+
+class Channel extends BaseChannel
+{
+    use \Sylius\MultiStorePlugin\CustomerPools\Domain\Model\CustomerPoolAwareTrait;
+    public function __construct()
+    {
+        $this->initializeSomething();
+    }
+}
+
+?>

--- a/tests/Rector/Class_/AddMethodCallToConstructorForClassesUsingTrait/Fixture/class_with_two_traits.php.inc
+++ b/tests/Rector/Class_/AddMethodCallToConstructorForClassesUsingTrait/Fixture/class_with_two_traits.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Sylius\SyliusRector\Tests\Rector\Class_\AddMethodCallToConstructorForClassesUsingTrait\Fixture;
+
+use Sylius\Component\Core\Model\Channel as BaseChannel;
+
+class Channel extends BaseChannel
+{
+    use \Sylius\MultiStorePlugin\BusinessUnits\Domain\Model\BusinessUnitAwareTrait;
+    use \Sylius\MultiStorePlugin\CustomerPools\Domain\Model\CustomerPoolAwareTrait;
+}
+
+?>
+-----
+<?php
+
+namespace Sylius\SyliusRector\Tests\Rector\Class_\AddMethodCallToConstructorForClassesUsingTrait\Fixture;
+
+use Sylius\Component\Core\Model\Channel as BaseChannel;
+
+class Channel extends BaseChannel
+{
+    use \Sylius\MultiStorePlugin\BusinessUnits\Domain\Model\BusinessUnitAwareTrait;
+    use \Sylius\MultiStorePlugin\CustomerPools\Domain\Model\CustomerPoolAwareTrait;
+    public function __construct()
+    {
+        $this->initializeSomething();
+        $this->initializeSomethingElse();
+    }
+}
+
+?>

--- a/tests/Rector/Class_/AddMethodCallToConstructorForClassesUsingTrait/Fixture/class_without_constructor.php.inc
+++ b/tests/Rector/Class_/AddMethodCallToConstructorForClassesUsingTrait/Fixture/class_without_constructor.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Sylius\SyliusRector\Tests\Rector\Class_\AddMethodCallToConstructorForClassesUsingTrait\Fixture;
+
+use Sylius\Component\Core\Model\Channel as BaseChannel;
+
+class Channel extends BaseChannel
+{
+    use \Sylius\MultiStorePlugin\CustomerPools\Domain\Model\CustomerPoolAwareTrait;
+}
+
+?>
+-----
+<?php
+
+namespace Sylius\SyliusRector\Tests\Rector\Class_\AddMethodCallToConstructorForClassesUsingTrait\Fixture;
+
+use Sylius\Component\Core\Model\Channel as BaseChannel;
+
+class Channel extends BaseChannel
+{
+    use \Sylius\MultiStorePlugin\CustomerPools\Domain\Model\CustomerPoolAwareTrait;
+    public function __construct()
+    {
+        $this->initializeSomething();
+    }
+}
+
+?>

--- a/tests/Rector/Class_/AddMethodCallToConstructorForClassesUsingTrait/config/configured_rule.php
+++ b/tests/Rector/Class_/AddMethodCallToConstructorForClassesUsingTrait/config/configured_rule.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Sylius\SyliusRector\Rector\Class_\AddMethodCallToConstructorForClassesUsingTraitRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+    $rectorConfig->ruleWithConfiguration(AddMethodCallToConstructorForClassesUsingTraitRector::class, [
+        'Sylius\MultiStorePlugin\CustomerPools\Domain\Model\CustomerPoolAwareTrait' => [
+            [
+                'variableName' => 'this',
+                'method' => 'initializeSomething',
+                'arguments' => [],
+            ],
+        ],
+        'Sylius\MultiStorePlugin\BusinessUnits\Domain\Model\BusinessUnitAwareTrait' => [
+            [
+                'variableName' => 'this',
+                'method' => 'initializeSomethingElse',
+                'arguments' => [],
+            ],
+        ],
+    ]);
+};

--- a/tests/Rector/Class_/AddMethodCallToConstructorForClassesUsingTrait/config/configured_rule.php
+++ b/tests/Rector/Class_/AddMethodCallToConstructorForClassesUsingTrait/config/configured_rule.php
@@ -4,23 +4,16 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Sylius\SyliusRector\Rector\Class_\AddMethodCallToConstructorForClassesUsingTraitRector;
+use Sylius\SyliusRector\Rector\Dto\AddMethodCallToConstructorForClassesUsingTrait;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
     $rectorConfig->ruleWithConfiguration(AddMethodCallToConstructorForClassesUsingTraitRector::class, [
         'Sylius\MultiStorePlugin\CustomerPools\Domain\Model\CustomerPoolAwareTrait' => [
-            [
-                'variableName' => 'this',
-                'method' => 'initializeSomething',
-                'arguments' => [],
-            ],
+            new AddMethodCallToConstructorForClassesUsingTrait('this', 'initializeSomething'),
         ],
         'Sylius\MultiStorePlugin\BusinessUnits\Domain\Model\BusinessUnitAwareTrait' => [
-            [
-                'variableName' => 'this',
-                'method' => 'initializeSomethingElse',
-                'arguments' => [],
-            ],
+            new AddMethodCallToConstructorForClassesUsingTrait('this', 'initializeSomethingElse')
         ],
     ]);
 };

--- a/tests/Rector/TraitUse/AliasTraitMethod/AliasTraitMethodTest.php
+++ b/tests/Rector/TraitUse/AliasTraitMethod/AliasTraitMethodTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\SyliusRector\Tests\Rector\TraitUse\AliasTraitMethod;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class AliasTraitMethodTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/TraitUse/AliasTraitMethod/Fixture/class_using_trait_with_already_existing_alias.php.inc
+++ b/tests/Rector/TraitUse/AliasTraitMethod/Fixture/class_using_trait_with_already_existing_alias.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Sylius\SyliusRector\Tests\Rector\Class_\AddInterfaceToClassExtendingType\Fixture;
+
+use Sylius\Component\Core\Model\Channel as BaseChannel;
+
+class Channel extends BaseChannel
+{
+    use \Sylius\MultiStorePlugin\CustomerPools\Domain\Model\CustomerPoolAwareTrait {
+        __construct as private initializeNothing;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Sylius\SyliusRector\Tests\Rector\Class_\AddInterfaceToClassExtendingType\Fixture;
+
+use Sylius\Component\Core\Model\Channel as BaseChannel;
+
+class Channel extends BaseChannel
+{
+    use \Sylius\MultiStorePlugin\CustomerPools\Domain\Model\CustomerPoolAwareTrait {
+        __construct as private initializeSomething;
+    }
+}
+
+?>

--- a/tests/Rector/TraitUse/AliasTraitMethod/Fixture/class_using_trait_without_any_alias.php.inc
+++ b/tests/Rector/TraitUse/AliasTraitMethod/Fixture/class_using_trait_without_any_alias.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Sylius\SyliusRector\Tests\Rector\Class_\AddInterfaceToClassExtendingType\Fixture;
+
+use Sylius\Component\Core\Model\Channel as BaseChannel;
+
+class Channel extends BaseChannel
+{
+    use \Sylius\MultiStorePlugin\CustomerPools\Domain\Model\CustomerPoolAwareTrait;
+}
+
+?>
+-----
+<?php
+
+namespace Sylius\SyliusRector\Tests\Rector\Class_\AddInterfaceToClassExtendingType\Fixture;
+
+use Sylius\Component\Core\Model\Channel as BaseChannel;
+
+class Channel extends BaseChannel
+{
+    use \Sylius\MultiStorePlugin\CustomerPools\Domain\Model\CustomerPoolAwareTrait {
+        __construct as private initializeSomething;
+    }
+}
+
+?>

--- a/tests/Rector/TraitUse/AliasTraitMethod/config/configured_rule.php
+++ b/tests/Rector/TraitUse/AliasTraitMethod/config/configured_rule.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpParser\Node\Stmt\Class_;
+use Rector\Config\RectorConfig;
+use Sylius\SyliusRector\Rector\TraitUse\AliasTraitMethodRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+    $rectorConfig->ruleWithConfiguration(AliasTraitMethodRector::class, [
+        'Sylius\MultiStorePlugin\CustomerPools\Domain\Model\CustomerPoolAwareTrait' => [
+            [
+                'traitMethod' => '__construct',
+                'newMethodName' => 'initializeSomething',
+                'visibility' => Class_::MODIFIER_PRIVATE,
+            ],
+        ],
+    ]);
+};


### PR DESCRIPTION
Hi!

This PR comes with two new rules. From now, we can alias trait's methods
```diff
use Sylius\Component\Core\Model\Channel as BaseChannel;

class Channel extends BaseChannel
{
-    use \Sylius\MultiStorePlugin\CustomerPools\Domain\Model\CustomerPoolAwareTrait;
+    use \Sylius\MultiStorePlugin\CustomerPools\Domain\Model\CustomerPoolAwareTrait {
+        __construct as private initializeSomething;
+    }
}
```

and add a method call to the constructor for every class using the given trait

```diff
use Sylius\Component\Core\Model\Channel as BaseChannel;

class Channel extends BaseChannel
{
    use \Sylius\MultiStorePlugin\CustomerPools\Domain\Model\CustomerPoolAwareTrait;
    public function __construct()
    {
+        $this->initializeSomething();
    }
}
```