### PR TITLE
[Readme] composer require rector/rector - step removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ Starting with Sylius-Standard 1.12 and above, we are providing a basic configura
 
 Then, when you meet the minimal requirements, run the following commands:
 ```bash
-composer require rector/rector --dev
-composer require sylius/sylius-rector
+composer require sylius/sylius-rector --dev
 ```
 
 Finally, create `<project_root>/rector.php` file with the following content:


### PR DESCRIPTION
If we first run the `composer require rector/rector --dev` we may end up with a rector conflict in `sylius/sylius-rector`. Since `sylius/sylius-rector` depends on the `rector/rector` we only need to run one command and keep rector's upgrades in one place
  
Picrel:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/40125720/196785354-1d35bf5b-8311-43cb-afd3-36244e820c95.png">

Only `sylius/sylius-rector` required: 
<img width="1088" alt="image" src="https://user-images.githubusercontent.com/40125720/196785786-8cdb4418-1c99-4069-a967-9825212a2f8c.png">
