### PR TITLE
[Maintenance] Rector version upgrade, static analysis included

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,3 +27,5 @@ jobs:
             -   uses: "ramsey/composer-install@v1"
 
             -   run: vendor/bin/phpunit tests
+
+            -   run: vendor/bin/phpstan analyse

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "Rector upgrades rules for Sylius",
     "require": {
         "php": "^8.0",
-        "rector/rector": "^0.13"
+        "rector/rector": "^0.14"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/config/config.php
+++ b/config/config.php
@@ -6,11 +6,12 @@ use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
     $services = $rectorConfig->services();
-    $services->defaults()
-        ->public()
-        ->autowire()
-        ->autoconfigure();
+    $configurator = $services->defaults();
 
-    $services->load('Sylius\\SyliusRector\\', __DIR__ . '/../src')
-        ->exclude([__DIR__ . '/../src/Rector', __DIR__ . '/../src/ValueObject', __DIR__ . '/../src/PhpDoc/Node']);
+    $configurator->public();
+    $configurator->autowire();
+    $configurator->autoconfigure();
+
+    $prototypeConfigurator = $services->load('Sylius\\SyliusRector\\', __DIR__ . '/../src');
+    $prototypeConfigurator->exclude([__DIR__ . '/../src/Rector', __DIR__ . '/../src/ValueObject', __DIR__ . '/../src/PhpDoc/Node']);
 };

--- a/tests/Rector/Class_/AddInterfaceToClassExtendingType/AddInterfaceToClassExtendingTypeTest.php
+++ b/tests/Rector/Class_/AddInterfaceToClassExtendingType/AddInterfaceToClassExtendingTypeTest.php
@@ -6,20 +6,19 @@ namespace Sylius\SyliusRector\Tests\Rector\Class_\AddInterfaceToClassExtendingTy
 
 use Iterator;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class AddInterfaceToClassExtendingTypeTest extends AbstractRectorTestCase
 {
     /**
      * @dataProvider provideData()
      */
-    public function test(SmartFileInfo $fileInfo): void
+    public function test(string $file): void
     {
-        $this->doTestFileInfo($fileInfo);
+        $this->doTestFile($file);
     }
 
     /**
-     * @return Iterator<SmartFileInfo>
+     * @return Iterator<string>
      */
     public function provideData(): Iterator
     {

--- a/tests/Rector/Class_/AddMethodCallToConstructorForClassesUsingTrait/AddMethodCallToConstructorForClassesUsingTraitTest.php
+++ b/tests/Rector/Class_/AddMethodCallToConstructorForClassesUsingTrait/AddMethodCallToConstructorForClassesUsingTraitTest.php
@@ -6,20 +6,19 @@ namespace Sylius\SyliusRector\Tests\Rector\Class_\AddMethodCallToConstructorForC
 
 use Iterator;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class AddMethodCallToConstructorForClassesUsingTraitTest extends AbstractRectorTestCase
 {
     /**
      * @dataProvider provideData()
      */
-    public function test(SmartFileInfo $fileInfo): void
+    public function test(string $file): void
     {
-        $this->doTestFileInfo($fileInfo);
+        $this->doTestFile($file);
     }
 
     /**
-     * @return Iterator<SmartFileInfo>
+     * @return Iterator<string>
      */
     public function provideData(): Iterator
     {

--- a/tests/Rector/Class_/AddTraitToClassExtendingType/AddTraitToClassExtendingTypeTest.php
+++ b/tests/Rector/Class_/AddTraitToClassExtendingType/AddTraitToClassExtendingTypeTest.php
@@ -6,20 +6,19 @@ namespace Sylius\SyliusRector\Tests\Rector\Class_\AddTraitToClassExtendingType;
 
 use Iterator;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class AddTraitToClassExtendingTypeTest extends AbstractRectorTestCase
 {
     /**
      * @dataProvider provideData()
      */
-    public function test(SmartFileInfo $fileInfo): void
+    public function test(string $file): void
     {
-        $this->doTestFileInfo($fileInfo);
+        $this->doTestFile($file);
     }
 
     /**
-     * @return Iterator<SmartFileInfo>
+     * @return Iterator<string>
      */
     public function provideData(): Iterator
     {

--- a/tests/Rector/TraitUse/AliasTraitMethod/AliasTraitMethodTest.php
+++ b/tests/Rector/TraitUse/AliasTraitMethod/AliasTraitMethodTest.php
@@ -6,20 +6,19 @@ namespace Sylius\SyliusRector\Tests\Rector\TraitUse\AliasTraitMethod;
 
 use Iterator;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class AliasTraitMethodTest extends AbstractRectorTestCase
 {
     /**
      * @dataProvider provideData()
      */
-    public function test(SmartFileInfo $fileInfo): void
+    public function test(string $file): void
     {
-        $this->doTestFileInfo($fileInfo);
+        $this->doTestFile($file);
     }
 
     /**
-     * @return Iterator<SmartFileInfo>
+     * @return Iterator<string>
      */
     public function provideData(): Iterator
     {

--- a/tests/Set/SyliusPlus/LoyaltyPlugin/MultiStorePluginTest.php
+++ b/tests/Set/SyliusPlus/LoyaltyPlugin/MultiStorePluginTest.php
@@ -6,20 +6,19 @@ namespace Sylius\SyliusRector\Tests\Set\SyliusPlus\LoyaltyPlugin;
 
 use Iterator;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class MultiStorePluginTest extends AbstractRectorTestCase
 {
     /**
      * @dataProvider provideData()
      */
-    public function test(SmartFileInfo $fileInfo): void
+    public function test(string $file): void
     {
-        $this->doTestFileInfo($fileInfo);
+        $this->doTestFile($file);
     }
 
     /**
-     * @return Iterator<SmartFileInfo>
+     * @return Iterator<string>
      */
     public function provideData(): Iterator
     {

--- a/tests/Set/SyliusPlus/MultiSourceInventoryPlugin/MultiSourceInventoryPluginTest.php
+++ b/tests/Set/SyliusPlus/MultiSourceInventoryPlugin/MultiSourceInventoryPluginTest.php
@@ -6,20 +6,19 @@ namespace Sylius\SyliusRector\Tests\Set\SyliusPlus\MultiSourceInventoryPlugin;
 
 use Iterator;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class MultiSourceInventoryPluginTest extends AbstractRectorTestCase
 {
     /**
      * @dataProvider provideData()
      */
-    public function test(SmartFileInfo $fileInfo): void
+    public function test(string $file): void
     {
-        $this->doTestFileInfo($fileInfo);
+        $this->doTestFile($file);
     }
 
     /**
-     * @return Iterator<SmartFileInfo>
+     * @return Iterator<string>
      */
     public function provideData(): Iterator
     {

--- a/tests/Set/SyliusPlus/MultiStorePlugin/MultiStorePluginTest.php
+++ b/tests/Set/SyliusPlus/MultiStorePlugin/MultiStorePluginTest.php
@@ -6,20 +6,19 @@ namespace Sylius\SyliusRector\Tests\Set\SyliusPlus\MultiStorePlugin;
 
 use Iterator;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class MultiStorePluginTest extends AbstractRectorTestCase
 {
     /**
      * @dataProvider provideData()
      */
-    public function test(SmartFileInfo $fileInfo): void
+    public function test(string $file): void
     {
-        $this->doTestFileInfo($fileInfo);
+        $this->doTestFile($file);
     }
 
     /**
-     * @return Iterator<SmartFileInfo>
+     * @return Iterator<string>
      */
     public function provideData(): Iterator
     {

--- a/tests/Set/SyliusPlus/PlusRbacPlugin/PlusRbacPluginTest.php
+++ b/tests/Set/SyliusPlus/PlusRbacPlugin/PlusRbacPluginTest.php
@@ -6,20 +6,19 @@ namespace Sylius\SyliusRector\Tests\Set\SyliusPlus\PlusRbacPlugin;
 
 use Iterator;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class PlusRbacPluginTest extends AbstractRectorTestCase
 {
     /**
      * @dataProvider provideData()
      */
-    public function test(SmartFileInfo $fileInfo): void
+    public function test(string $file): void
     {
-        $this->doTestFileInfo($fileInfo);
+        $this->doTestFile($file);
     }
 
     /**
-     * @return Iterator<SmartFileInfo>
+     * @return Iterator<string>
      */
     public function provideData(): Iterator
     {

--- a/tests/Set/SyliusPlus/ReturnPlugin/ReturnPluginTest.php
+++ b/tests/Set/SyliusPlus/ReturnPlugin/ReturnPluginTest.php
@@ -6,20 +6,19 @@ namespace Sylius\SyliusRector\Tests\Set\SyliusPlus\ReturnPlugin;
 
 use Iterator;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class ReturnPluginTest extends AbstractRectorTestCase
 {
     /**
      * @dataProvider provideData()
      */
-    public function test(SmartFileInfo $fileInfo): void
+    public function test(string $file): void
     {
-        $this->doTestFileInfo($fileInfo);
+        $this->doTestFile($file);
     }
 
     /**
-     * @return Iterator<SmartFileInfo>
+     * @return Iterator<string>
      */
     public function provideData(): Iterator
     {

--- a/tests/Set/UpgradeToPlusModular/MultiStorePluginTest.php
+++ b/tests/Set/UpgradeToPlusModular/MultiStorePluginTest.php
@@ -6,20 +6,19 @@ namespace Sylius\SyliusRector\Tests\Set\UpgradeToPlusModular;
 
 use Iterator;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class MultiStorePluginTest extends AbstractRectorTestCase
 {
     /**
      * @dataProvider provideData()
      */
-    public function test(SmartFileInfo $fileInfo): void
+    public function test(string $file): void
     {
-        $this->doTestFileInfo($fileInfo);
+        $this->doTestFile($file);
     }
 
     /**
-     * @return Iterator<SmartFileInfo>
+     * @return Iterator<string>
      */
     public function provideData(): Iterator
     {


### PR DESCRIPTION
As Sylius-Standard currently depends on `^0.14` rector version it is impossible to install `SyliusRector` without playing around with dependency versions.

<img width="1382" alt="image" src="https://user-images.githubusercontent.com/40125720/203077332-3a56fc23-be42-4fb8-9769-d869084306d5.png">
