### PR TITLE
Update CI workflow actions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,15 +15,15 @@ jobs:
 
         name: Tests
         steps:
-            -   uses: actions/checkout@v2
+            -   uses: actions/checkout@v4
 
             -
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.1
+                    php-version: 8.3
                     coverage: none
 
-            -   uses: "ramsey/composer-install@v1"
+            -   uses: "ramsey/composer-install@v3"
 
             -   run: vendor/bin/phpunit tests
 


### PR DESCRIPTION
Updates GitHub Actions workflow to use more recent versions:

- `actions/checkout` from v2 to v4
- `ramsey/composer-install` from v1 to v3
- PHP version from 8.1 to 8.3