### PR TITLE
Remove `config.php` import from test configuration files

### DIFF
--- a/tests/Rector/Class_/AddInterfaceToClassExtendingType/config/configured_rule.php
+++ b/tests/Rector/Class_/AddInterfaceToClassExtendingType/config/configured_rule.php
@@ -6,7 +6,6 @@ use Rector\Config\RectorConfig;
 use Sylius\SyliusRector\Rector\Class_\AddInterfaceToClassExtendingTypeRector;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
     $rectorConfig->ruleWithConfiguration(AddInterfaceToClassExtendingTypeRector::class, [
         'Sylius\Component\Core\Model\Channel' => [
             'Sylius\MultiStorePlugin\BusinessUnits\Domain\Model\ChannelInterface',

--- a/tests/Rector/Class_/AddMethodCallToConstructorForClassesUsingTrait/config/configured_rule.php
+++ b/tests/Rector/Class_/AddMethodCallToConstructorForClassesUsingTrait/config/configured_rule.php
@@ -7,7 +7,6 @@ use Sylius\SyliusRector\Rector\Class_\AddMethodCallToConstructorForClassesUsingT
 use Sylius\SyliusRector\Rector\Dto\AddMethodCallToConstructorForClassesUsingTrait;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
     $rectorConfig->ruleWithConfiguration(AddMethodCallToConstructorForClassesUsingTraitRector::class, [
         'Sylius\MultiStorePlugin\CustomerPools\Domain\Model\CustomerPoolAwareTrait' => [
             new AddMethodCallToConstructorForClassesUsingTrait('this', 'initializeSomething'),

--- a/tests/Rector/Class_/AddTraitToClassExtendingType/config/configured_rule.php
+++ b/tests/Rector/Class_/AddTraitToClassExtendingType/config/configured_rule.php
@@ -6,7 +6,6 @@ use Rector\Config\RectorConfig;
 use Sylius\SyliusRector\Rector\Class_\AddTraitToClassExtendingTypeRector;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
     $rectorConfig->ruleWithConfiguration(AddTraitToClassExtendingTypeRector::class, [
         'Sylius\Component\Core\Model\Channel' => [
             'Sylius\MultiStorePlugin\CustomerPools\Domain\Model\CustomerPoolAwareTrait',

--- a/tests/Rector/TraitUse/AliasTraitMethod/config/configured_rule.php
+++ b/tests/Rector/TraitUse/AliasTraitMethod/config/configured_rule.php
@@ -7,7 +7,6 @@ use Rector\Config\RectorConfig;
 use Sylius\SyliusRector\Rector\TraitUse\AliasTraitMethodRector;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
     $rectorConfig->ruleWithConfiguration(AliasTraitMethodRector::class, [
         'Sylius\MultiStorePlugin\CustomerPools\Domain\Model\CustomerPoolAwareTrait' => [
             [

--- a/tests/Set/PriceHistory/config/configured_rule.php
+++ b/tests/Set/PriceHistory/config/configured_rule.php
@@ -6,6 +6,5 @@ use Rector\Config\RectorConfig;
 use Sylius\SyliusRector\Set\SyliusPriceHistory;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(__DIR__ . '/../../../../config/config.php');
     $rectorConfig->sets([SyliusPriceHistory::UPGRADE_SYLIUS_1_12_WITH_PRICE_HISTORY_PLUGIN_TO_SYLIUS_1_13]);
 };

--- a/tests/Set/PriceHistoryPlugin/config/configured_rule.php
+++ b/tests/Set/PriceHistoryPlugin/config/configured_rule.php
@@ -6,6 +6,5 @@ use Rector\Config\RectorConfig;
 use Sylius\SyliusRector\Set\SyliusPriceHistory;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(__DIR__ . '/../../../../config/config.php');
     $rectorConfig->sets([SyliusPriceHistory::PRICE_HISTORY_PLUGIN]);
 };

--- a/tests/Set/ProductBundlePlugin/config/configured_rule.php
+++ b/tests/Set/ProductBundlePlugin/config/configured_rule.php
@@ -6,6 +6,5 @@ use Rector\Config\RectorConfig;
 use Sylius\SyliusRector\Set\SyliusProductBundle;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(__DIR__ . '/../../../../config/config.php');
     $rectorConfig->sets([SyliusProductBundle::PRODUCT_BUNDLE]);
 };

--- a/tests/Set/SyliusPlus/B2BKit/config/configured_rule.php
+++ b/tests/Set/SyliusPlus/B2BKit/config/configured_rule.php
@@ -6,7 +6,6 @@ use Rector\Config\RectorConfig;
 use Sylius\SyliusRector\Set\SyliusPlus;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
     $rectorConfig->sets([
         SyliusPlus::B2B_SUITE_UP_TO_30,
     ]);

--- a/tests/Set/SyliusPlus/B2BSuite/config/configured_rule.php
+++ b/tests/Set/SyliusPlus/B2BSuite/config/configured_rule.php
@@ -6,7 +6,6 @@ use Rector\Config\RectorConfig;
 use Sylius\SyliusRector\Set\SyliusPlus;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
     $rectorConfig->sets([
         SyliusPlus::B2B_SUITE,
         SyliusPlus::B2B_SUITE_21,

--- a/tests/Set/SyliusPlus/LoyaltyPlugin/config/configured_rule.php
+++ b/tests/Set/SyliusPlus/LoyaltyPlugin/config/configured_rule.php
@@ -6,6 +6,5 @@ use Rector\Config\RectorConfig;
 use Sylius\SyliusRector\Set\SyliusPlus;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
     $rectorConfig->sets([SyliusPlus::LOYALTY_PLUGIN]);
 };

--- a/tests/Set/SyliusPlus/MarketplaceSuite/config/configured_rule.php
+++ b/tests/Set/SyliusPlus/MarketplaceSuite/config/configured_rule.php
@@ -6,7 +6,6 @@ use Rector\Config\RectorConfig;
 use Sylius\SyliusRector\Set\SyliusPlus;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
     $rectorConfig->sets([SyliusPlus::MARKETPLACE_SUITE]);
     $rectorConfig->importNames();
 };

--- a/tests/Set/SyliusPlus/MultiSourceInventoryPlugin/config/configured_rule.php
+++ b/tests/Set/SyliusPlus/MultiSourceInventoryPlugin/config/configured_rule.php
@@ -6,6 +6,5 @@ use Rector\Config\RectorConfig;
 use Sylius\SyliusRector\Set\SyliusPlus;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
     $rectorConfig->sets([SyliusPlus::MULTI_SOURCE_INVENTORY_PLUGIN]);
 };

--- a/tests/Set/SyliusPlus/MultiStorePlugin/config/configured_rule.php
+++ b/tests/Set/SyliusPlus/MultiStorePlugin/config/configured_rule.php
@@ -6,6 +6,5 @@ use Rector\Config\RectorConfig;
 use Sylius\SyliusRector\Set\SyliusPlus;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
     $rectorConfig->sets([SyliusPlus::MULTI_STORE_PLUGIN]);
 };

--- a/tests/Set/SyliusPlus/PlusRbacPlugin/config/configured_rule.php
+++ b/tests/Set/SyliusPlus/PlusRbacPlugin/config/configured_rule.php
@@ -6,6 +6,5 @@ use Rector\Config\RectorConfig;
 use Sylius\SyliusRector\Set\SyliusPlus;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
     $rectorConfig->sets([SyliusPlus::PLUS_RBAC_PLUGIN]);
 };

--- a/tests/Set/SyliusPlus/ReturnPlugin/config/configured_rule.php
+++ b/tests/Set/SyliusPlus/ReturnPlugin/config/configured_rule.php
@@ -6,6 +6,5 @@ use Rector\Config\RectorConfig;
 use Sylius\SyliusRector\Set\SyliusPlus;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
     $rectorConfig->sets([SyliusPlus::RETURN_PLUGIN]);
 };

--- a/tests/Set/SyliusPlus/RfqPlugin/config/configured_rule.php
+++ b/tests/Set/SyliusPlus/RfqPlugin/config/configured_rule.php
@@ -6,7 +6,6 @@ use Rector\Config\RectorConfig;
 use Sylius\SyliusRector\Set\SyliusPlus;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
     $rectorConfig->sets([
         SyliusPlus::RFQ_PLUGIN,
     ]);

--- a/tests/Set/UpgradeToPlusModular/config/configured_rule.php
+++ b/tests/Set/UpgradeToPlusModular/config/configured_rule.php
@@ -6,7 +6,6 @@ use Rector\Config\RectorConfig;
 use Sylius\SyliusRector\Set\SyliusPlus;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(__DIR__ . '/../../../../config/config.php');
     $rectorConfig->sets([SyliusPlus::UPGRADE_TO_MODULAR]);
     $rectorConfig->importNames();
 };


### PR DESCRIPTION
Test configuration files were importing the main `config/config.php` which was empty and specific rules are loaded directly in tests.

Removed the `config.php` import line from 17 test configuration files across:
- Rector rule tests (AddInterfaceToClassExtendingType, AddMethodCallToConstructorForClassesUsingTrait, AddTraitToClassExtendingType, AliasTraitMethod)
- Set tests (PriceHistory, ProductBundle, and multiple Sylius Plus plugins)