### PR TITLE
Add SetProvider infrastructure with extension-installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "description": "Rector upgrades rules for Sylius",
     "require": {
         "php": "^8.0",
-        "rector/rector": "^2.0.7"
+        "rector/rector": "^2.0",
+        "rector/extension-installer": "~0.11"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5.44",

--- a/config/config.php
+++ b/config/config.php
@@ -3,6 +3,9 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Sylius\SyliusRector\SetProvider\SyliusSetProvider;
 
-return static function (RectorConfig $rectorConfig): void {
-};
+return RectorConfig::configure()
+    ->withSetProviders(SyliusSetProvider::class)
+    ->withComposerBased(symfony: true)
+;

--- a/src/SetProvider/SyliusSetProvider.php
+++ b/src/SetProvider/SyliusSetProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\SyliusRector\SetProvider;
+
+use Rector\Set\Contract\SetProviderInterface;
+use Rector\Set\ValueObject\ComposerTriggeredSet;
+
+final class SyliusSetProvider implements SetProviderInterface
+{
+    /** @return ComposerTriggeredSet[] */
+    public function provide(): array
+    {
+        return [
+        ];
+    }
+}


### PR DESCRIPTION
Implements SetProvider infrastructure to prepare for composer-triggered Rector sets.

Changes:
- Add `rector/extension-installer` dependency (~0.11)
- Update `config/config.php` to use `RectorConfig::configure()` syntax
- Add `SyliusSetProvider` implementing `SetProviderInterface`
- Enable composer-based configuration with `withComposerBased(symfony: true)`
- Register `SyliusSetProvider` for future set definitions

This sets up the foundation for automatic application of upgrade rules based on detected Composer packages, making Rector configuration more user-friendly.