### PR TITLE
Add Channel entity transformation rules for B2B Kit 3.0

### DIFF
--- a/config/sets/sylius/b2b-kit/b2b-kit-3.0.php
+++ b/config/sets/sylius/b2b-kit/b2b-kit-3.0.php
@@ -15,6 +15,9 @@ return static function (RectorConfig $rectorConfig): void {
         'Sylius\Component\Core\Model\Address' => [
             'Sylius\B2BKit\Organization\Entity\AddressInterface',
         ],
+        'Sylius\Component\Core\Model\Channel' => [
+            'Sylius\B2BKit\HidePrices\Entity\ChannelInterface',
+        ],
         'Sylius\Component\Core\Model\Customer' => [
             'Sylius\B2BKit\Organization\Entity\CustomerInterface',
         ],
@@ -35,6 +38,9 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->ruleWithConfiguration(AddTraitToClassExtendingTypeRector::class, [
         'Sylius\Component\Core\Model\Address' => [
             'Sylius\B2BKit\Organization\Entity\AddressAwareTrait',
+        ],
+        'Sylius\Component\Core\Model\Channel' => [
+            'Sylius\B2BKit\HidePrices\Entity\ChannelLoginRequiredTrait',
         ],
         'Sylius\Component\Core\Model\Customer' => [
             'Sylius\B2BKit\Organization\Entity\CustomerAwareTrait',


### PR DESCRIPTION
Adds missing rector rules for Channel entity transformation in the B2B Kit 3.0 set. The rules add ChannelInterface from the HidePrices component and apply ChannelLoginRequiredTrait to Channel entities extending Sylius\Component\Core\Model\Channel.

Changes:
- Add ChannelInterface implementation rule
- Add ChannelLoginRequiredTrait usage rule