### PR TITLE
Enable automatic namespace imports

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -7,5 +7,6 @@ use Sylius\SyliusRector\SetProvider\SyliusSetProvider;
 
 return RectorConfig::configure()
     ->withSetProviders(SyliusSetProvider::class)
+    ->withImportNames()
     ->withComposerBased(symfony: true)
 ;

--- a/tests/Set/AdyenPlugin/Fixture/class_extending_core_product_variant_model.php.inc
+++ b/tests/Set/AdyenPlugin/Fixture/class_extending_core_product_variant_model.php.inc
@@ -14,11 +14,13 @@ class ProductVariant extends BaseProductVariant
 
 namespace Sylius\SyliusRector\Tests\Set\AdyenPlugin\Fixture;
 
+use Sylius\AdyenPlugin\Entity\CommodityCodeAwareInterface;
+use Sylius\AdyenPlugin\Entity\CommodityCodeAwareTrait;
 use Sylius\Component\Core\Model\ProductVariant as BaseProductVariant;
 
-class ProductVariant extends BaseProductVariant implements \Sylius\AdyenPlugin\Entity\CommodityCodeAwareInterface
+class ProductVariant extends BaseProductVariant implements CommodityCodeAwareInterface
 {
-    use \Sylius\AdyenPlugin\Entity\CommodityCodeAwareTrait;
+    use CommodityCodeAwareTrait;
 }
 
 ?>

--- a/tests/Set/MolliePlugin/Fixture/Add/class_extending_core_admin_user_model.php.inc
+++ b/tests/Set/MolliePlugin/Fixture/Add/class_extending_core_admin_user_model.php.inc
@@ -14,11 +14,13 @@ class AdminUser extends BaseAdminUser
 
 namespace Sylius\SyliusRector\Tests\Set\MolliePlugin\Fixture\Add;
 
+use Sylius\MolliePlugin\Entity\OnboardingStatusAwareInterface;
+use Sylius\MolliePlugin\Entity\OnboardingStatusAwareTrait;
 use Sylius\Component\Core\Model\AdminUser as BaseAdminUser;
 
-class AdminUser extends BaseAdminUser implements \Sylius\MolliePlugin\Entity\OnboardingStatusAwareInterface
+class AdminUser extends BaseAdminUser implements OnboardingStatusAwareInterface
 {
-    use \Sylius\MolliePlugin\Entity\OnboardingStatusAwareTrait;
+    use OnboardingStatusAwareTrait;
 }
 
 ?>

--- a/tests/Set/MolliePlugin/Fixture/Add/class_extending_core_gateway_config_model.php.inc
+++ b/tests/Set/MolliePlugin/Fixture/Add/class_extending_core_gateway_config_model.php.inc
@@ -14,11 +14,13 @@ class GatewayConfig extends BaseGatewayConfig
 
 namespace Sylius\SyliusRector\Tests\Set\MolliePlugin\Fixture\Add;
 
+use Sylius\MolliePlugin\Entity\GatewayConfigInterface;
+use Sylius\MolliePlugin\Entity\GatewayConfigTrait;
 use Sylius\Bundle\PayumBundle\Model\GatewayConfig as BaseGatewayConfig;
 
-class GatewayConfig extends BaseGatewayConfig implements \Sylius\MolliePlugin\Entity\GatewayConfigInterface
+class GatewayConfig extends BaseGatewayConfig implements GatewayConfigInterface
 {
-    use \Sylius\MolliePlugin\Entity\GatewayConfigTrait;
+    use GatewayConfigTrait;
     public function __construct()
     {
         parent::__construct();

--- a/tests/Set/MolliePlugin/Fixture/Add/class_extending_core_order_model.php.inc
+++ b/tests/Set/MolliePlugin/Fixture/Add/class_extending_core_order_model.php.inc
@@ -14,14 +14,19 @@ class Order extends BaseOrder
 
 namespace Sylius\SyliusRector\Tests\Set\MolliePlugin\Fixture\Add;
 
+use Sylius\MolliePlugin\Entity\OrderInterface;
+use Sylius\MolliePlugin\Entity\MolliePaymentIdOrderTrait;
+use Sylius\MolliePlugin\Entity\QRCodeOrderTrait;
+use Sylius\MolliePlugin\Entity\RecurringOrderTrait;
+use Sylius\MolliePlugin\Entity\AbandonedEmailOrderTrait;
 use Sylius\Component\Core\Model\Order as BaseOrder;
 
-class Order extends BaseOrder implements \Sylius\MolliePlugin\Entity\OrderInterface
+class Order extends BaseOrder implements OrderInterface
 {
-    use \Sylius\MolliePlugin\Entity\MolliePaymentIdOrderTrait;
-    use \Sylius\MolliePlugin\Entity\QRCodeOrderTrait;
-    use \Sylius\MolliePlugin\Entity\RecurringOrderTrait;
-    use \Sylius\MolliePlugin\Entity\AbandonedEmailOrderTrait;
+    use MolliePaymentIdOrderTrait;
+    use QRCodeOrderTrait;
+    use RecurringOrderTrait;
+    use AbandonedEmailOrderTrait;
 }
 
 ?>

--- a/tests/Set/MolliePlugin/Fixture/Add/class_extending_core_product_model.php.inc
+++ b/tests/Set/MolliePlugin/Fixture/Add/class_extending_core_product_model.php.inc
@@ -14,11 +14,13 @@ class Product extends BaseProduct
 
 namespace Sylius\SyliusRector\Tests\Set\MolliePlugin\Fixture\Add;
 
+use Sylius\MolliePlugin\Entity\ProductInterface;
+use Sylius\MolliePlugin\Entity\ProductTrait;
 use Sylius\Component\Core\Model\Product as BaseProduct;
 
-class Product extends BaseProduct implements \Sylius\MolliePlugin\Entity\ProductInterface
+class Product extends BaseProduct implements ProductInterface
 {
-    use \Sylius\MolliePlugin\Entity\ProductTrait;
+    use ProductTrait;
 }
 
 ?>

--- a/tests/Set/MolliePlugin/Fixture/Add/class_extending_core_product_variant_model.php.inc
+++ b/tests/Set/MolliePlugin/Fixture/Add/class_extending_core_product_variant_model.php.inc
@@ -14,11 +14,13 @@ class ProductVariant extends BaseProductVariant
 
 namespace Sylius\SyliusRector\Tests\Set\MolliePlugin\Fixture\Add;
 
+use Sylius\MolliePlugin\Entity\ProductVariantInterface;
+use Sylius\MolliePlugin\Entity\RecurringProductVariantTrait;
 use Sylius\Component\Core\Model\ProductVariant as BaseProductVariant;
 
-class ProductVariant extends BaseProductVariant implements \Sylius\MolliePlugin\Entity\ProductVariantInterface
+class ProductVariant extends BaseProductVariant implements ProductVariantInterface
 {
-    use \Sylius\MolliePlugin\Entity\RecurringProductVariantTrait;
+    use RecurringProductVariantTrait;
 }
 
 ?>


### PR DESCRIPTION
Adds `withImportNames()` to Rector configuration to automatically import fully qualified class names instead of using them inline. This makes generated code cleaner and follows PSR conventions.

Updated test fixtures for Adyen and Mollie plugins to expect imported names rather than fully qualified namespaces.