### PR TITLE
[B2B Kit] Add AddAttributeOverridesToClassExtendingTypeRector

### DIFF
--- a/config/sets/sylius/b2b-kit/b2b-kit-3.0.php
+++ b/config/sets/sylius/b2b-kit/b2b-kit-3.0.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 use Composer\InstalledVersions;
 use PhpParser\Node\Stmt\Class_;
 use Rector\Config\RectorConfig;
+use Sylius\SyliusRector\Rector\Class_\AddAttributeOverridesToClassExtendingTypeRector;
 use Sylius\SyliusRector\Rector\Class_\AddInterfaceToClassExtendingTypeRector;
 use Sylius\SyliusRector\Rector\Class_\AddMethodCallToConstructorForClassesUsingTraitRector;
 use Sylius\SyliusRector\Rector\Class_\AddTraitToClassExtendingTypeRector;
 use Sylius\SyliusRector\Rector\Dto\AddMethodCallToConstructorForClassesUsingTrait;
+use Sylius\SyliusRector\Rector\Dto\AttributeOverride;
 use Sylius\SyliusRector\Rector\TraitUse\AliasTraitMethodRector;
 
 return static function (RectorConfig $rectorConfig): void {
@@ -33,6 +35,13 @@ return static function (RectorConfig $rectorConfig): void {
         ],
         'Sylius\Component\Core\Model\Product' => [
             'Sylius\B2BKit\Organization\Entity\ProductInterface',
+        ],
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(AddAttributeOverridesToClassExtendingTypeRector::class, [
+        'Sylius\Component\Core\Model\Address' => [
+            new AttributeOverride('firstName', 'first_name', 'string', true),
+            new AttributeOverride('lastName', 'last_name', 'string', true),
         ],
     ]);
 

--- a/config/sets/sylius/b2b-kit/b2b-kit-3.0.php
+++ b/config/sets/sylius/b2b-kit/b2b-kit-3.0.php
@@ -73,7 +73,9 @@ return static function (RectorConfig $rectorConfig): void {
         ],
     ]);
 
-    $b2bVersion = InstalledVersions::getVersion('sylius/b2b-kit');
+    $b2bVersion = InstalledVersions::isInstalled('sylius/b2b-kit')
+        ? InstalledVersions::getVersion('sylius/b2b-kit')
+        : null;
 
     if ($b2bVersion !== null && version_compare($b2bVersion, '3.0.2', '<')) {
         $rectorConfig->ruleWithConfiguration(AliasTraitMethodRector::class, [

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,6 +11,16 @@ parameters:
 			path: src/Rector/Class_/AddInterfaceToClassExtendingTypeRector.php
 
 		-
+			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Stmt\\\\Class_\\) of method Sylius\\\\SyliusRector\\\\Rector\\\\Class_\\\\AddAttributeOverridesToClassExtendingTypeRector\\:\\:refactor\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Rector\\\\Contract\\\\Rector\\\\RectorInterface\\:\\:refactor\\(\\)$#"
+			count: 3
+			path: src/Rector/Class_/AddAttributeOverridesToClassExtendingTypeRector.php
+
+		-
+			message: "#^Property Sylius\\\\SyliusRector\\\\Rector\\\\Class_\\\\AddAttributeOverridesToClassExtendingTypeRector\\:\\:\\$configuration type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Rector/Class_/AddAttributeOverridesToClassExtendingTypeRector.php
+
+		-
 			message: "#^Method Sylius\\\\SyliusRector\\\\Rector\\\\Class_\\\\AddMethodCallToConstructorForClassesUsingTraitRector\\:\\:refactor\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Rector/Class_/AddMethodCallToConstructorForClassesUsingTraitRector.php

--- a/src/Rector/Class_/AddAttributeOverridesToClassExtendingTypeRector.php
+++ b/src/Rector/Class_/AddAttributeOverridesToClassExtendingTypeRector.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\SyliusRector\Rector\Class_;
+
+use PhpParser\Comment;
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Scalar\Int_;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
+use Rector\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Rector\AbstractRector;
+use Sylius\SyliusRector\NodeManipulator\ClassInheritanceManipulator;
+use Sylius\SyliusRector\Rector\Dto\AttributeOverride;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Sylius\SyliusRector\Tests\Rector\Class_\AddAttributeOverridesToClassExtendingType\AddAttributeOverridesToClassExtendingTypeRectorTest
+ */
+final class AddAttributeOverridesToClassExtendingTypeRector extends AbstractRector implements ConfigurableRectorInterface
+{
+    /** @var array<string, AttributeOverride[]> */
+    private array $configuration = [];
+
+    public function __construct(
+        private ClassInheritanceManipulator $classInheritanceManipulator,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Adds ORM\AttributeOverrides to classes extending the given type',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+use Doctrine\ORM\Mapping as ORM;
+use Sylius\Component\Core\Model\Address as BaseAddress;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'sylius_address')]
+class Address extends BaseAddress
+{
+}
+CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
+use Doctrine\ORM\Mapping as ORM;
+use Sylius\Component\Core\Model\Address as BaseAddress;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'sylius_address')]
+#[ORM\AttributeOverrides([
+    new ORM\AttributeOverride(name: 'firstName', column: new ORM\Column(name: 'first_name', type: 'string', nullable: true)),
+    new ORM\AttributeOverride(name: 'lastName', column: new ORM\Column(name: 'last_name', type: 'string', nullable: true)),
+])]
+class Address extends BaseAddress
+{
+}
+CODE_SAMPLE,
+                ),
+            ],
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    public function configure(array $configuration): void
+    {
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $hasChanges = false;
+
+        foreach ($this->configuration as $className => $overrides) {
+            if (!$this->classInheritanceManipulator->isDerivative($node, $className)) {
+                continue;
+            }
+
+            if ($this->hasAttributeOverrides($node)) {
+                continue;
+            }
+
+            $this->addAttributeOverrides($node, $overrides);
+            $hasChanges = true;
+        }
+
+        return $hasChanges ? $node : null;
+    }
+
+    private function hasAttributeOverrides(Class_ $node): bool
+    {
+        foreach ($node->attrGroups as $attrGroup) {
+            foreach ($attrGroup->attrs as $attr) {
+                $attrName = $attr->name->toString();
+                if (
+                    $attrName === 'Doctrine\ORM\Mapping\AttributeOverrides' ||
+                    $attrName === 'ORM\AttributeOverrides' ||
+                    $attrName === 'AttributeOverrides'
+                ) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param AttributeOverride[] $overrides
+     */
+    private function addAttributeOverrides(Class_ $node, array $overrides): void
+    {
+        $overrideItems = [];
+        $isFirst = true;
+
+        foreach ($overrides as $override) {
+            $newExpr = $this->createAttributeOverrideNew($override);
+
+            if ($isFirst) {
+                $newExpr->setAttribute('comments', [new Comment("\n        ")]);
+                $isFirst = false;
+            } else {
+                $newExpr->setAttribute('comments', [new Comment("\n        ")]);
+            }
+
+            $overrideItems[] = new ArrayItem($newExpr);
+        }
+
+        $array = new Array_($overrideItems, ['kind' => Array_::KIND_SHORT]);
+
+        $attribute = new Attribute(
+            new FullyQualified('Doctrine\ORM\Mapping\AttributeOverrides'),
+            [new Arg($array)],
+        );
+
+        $node->attrGroups[] = new AttributeGroup([$attribute]);
+    }
+
+    private function createAttributeOverrideNew(AttributeOverride $override): New_
+    {
+        $columnArgs = [
+            new Arg(new String_($override->columnName), false, false, [], new Identifier('name')),
+            new Arg(new String_($override->type), false, false, [], new Identifier('type')),
+            new Arg(
+                $override->nullable ? new ConstFetch(new Name('true')) : new ConstFetch(new Name('false')),
+                false,
+                false,
+                [],
+                new Identifier('nullable'),
+            ),
+        ];
+
+        if ($override->length !== null) {
+            $columnArgs[] = new Arg(new Int_($override->length), false, false, [], new Identifier('length'));
+        }
+
+        $columnNew = new New_(
+            new FullyQualified('Doctrine\ORM\Mapping\Column'),
+            $columnArgs,
+        );
+
+        return new New_(
+            new FullyQualified('Doctrine\ORM\Mapping\AttributeOverride'),
+            [
+                new Arg(new String_($override->name), false, false, [], new Identifier('name')),
+                new Arg($columnNew, false, false, [], new Identifier('column')),
+            ],
+        );
+    }
+}

--- a/src/Rector/Dto/AttributeOverride.php
+++ b/src/Rector/Dto/AttributeOverride.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\SyliusRector\Rector\Dto;
+
+final class AttributeOverride
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly string $columnName,
+        public readonly string $type = 'string',
+        public readonly bool $nullable = false,
+        public readonly ?int $length = null,
+    ) {
+    }
+}

--- a/tests/Rector/Class_/AddAttributeOverridesToClassExtendingType/AddAttributeOverridesToClassExtendingTypeRectorTest.php
+++ b/tests/Rector/Class_/AddAttributeOverridesToClassExtendingType/AddAttributeOverridesToClassExtendingTypeRectorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\SyliusRector\Tests\Rector\Class_\AddAttributeOverridesToClassExtendingType;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AddAttributeOverridesToClassExtendingTypeRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $file): void
+    {
+        $this->doTestFile($file);
+    }
+
+    /**
+     * @return Iterator<string>
+     */
+    public function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/Class_/AddAttributeOverridesToClassExtendingType/Fixture/address_already_has_overrides.php.inc
+++ b/tests/Rector/Class_/AddAttributeOverridesToClassExtendingType/Fixture/address_already_has_overrides.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\Addressing;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\AttributeOverride;
+use Doctrine\ORM\Mapping\AttributeOverrides;
+use Doctrine\ORM\Mapping\Column;
+use Sylius\Component\Core\Model\Address as BaseAddress;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'sylius_address')]
+#[AttributeOverrides([new AttributeOverride(name: 'firstName', column: new Column(name: 'first_name', type: 'string', nullable: true))])]
+class Address extends BaseAddress
+{
+}
+
+?>

--- a/tests/Rector/Class_/AddAttributeOverridesToClassExtendingType/Fixture/address_entity.php.inc
+++ b/tests/Rector/Class_/AddAttributeOverridesToClassExtendingType/Fixture/address_entity.php.inc
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\Addressing;
+
+use Doctrine\ORM\Mapping as ORM;
+use Sylius\Component\Core\Model\Address as BaseAddress;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'sylius_address')]
+class Address extends BaseAddress
+{
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\Addressing;
+
+use Doctrine\ORM\Mapping as ORM;
+use Sylius\Component\Core\Model\Address as BaseAddress;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'sylius_address')]
+#[\Doctrine\ORM\Mapping\AttributeOverrides([new \Doctrine\ORM\Mapping\AttributeOverride(name: 'firstName', column: new \Doctrine\ORM\Mapping\Column(name: 'first_name', type: 'string', nullable: true)), new \Doctrine\ORM\Mapping\AttributeOverride(name: 'lastName', column: new \Doctrine\ORM\Mapping\Column(name: 'last_name', type: 'string', nullable: true))])]
+class Address extends BaseAddress
+{
+}
+
+?>

--- a/tests/Rector/Class_/AddAttributeOverridesToClassExtendingType/config/configured_rule.php
+++ b/tests/Rector/Class_/AddAttributeOverridesToClassExtendingType/config/configured_rule.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Sylius\SyliusRector\Rector\Class_\AddAttributeOverridesToClassExtendingTypeRector;
+use Sylius\SyliusRector\Rector\Dto\AttributeOverride;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(AddAttributeOverridesToClassExtendingTypeRector::class, [
+        'Sylius\Component\Core\Model\Address' => [
+            new AttributeOverride('firstName', 'first_name', 'string', true),
+            new AttributeOverride('lastName', 'last_name', 'string', true),
+        ],
+    ]);
+};


### PR DESCRIPTION
Adds a new Rector rule `AddAttributeOverridesToClassExtendingTypeRector` that automatically adds `ORM\AttributeOverrides` to entity classes extending a given type. Used in B2B Kit 3.0 to override `firstName` and `lastName` columns on Address entities.

- New `AddAttributeOverridesToClassExtendingTypeRector` configurable rule
- `AttributeOverride` DTO for defining column overrides (name, columnName, type, nullable, length)
- Configured for `Sylius\Component\Core\Model\Address` in `b2b-kit-3.0.php`